### PR TITLE
Delete all zeroes signature-check

### DIFF
--- a/app/Http/Controllers/TransactionsController.php
+++ b/app/Http/Controllers/TransactionsController.php
@@ -226,17 +226,12 @@ class TransactionsController extends AuthController
             if (strcmp($current_user->id, $transaction->user_id) != 0) {
                 throw new UnauthorizedException("User does not have permissions to access this transaction");
             }
-            if ($this->in_array_all(0, $request['signatureData'])) {
-                $ticket = 'test';
-            }
-            else {
-                $ticket = $this->generateRandomString();
-            }
+
+            $ticket = $this->generateRandomString();
             $transaction->ticket_otp = $ticket;
             $transaction->save();
 
-            if (strcmp($ticket, "test") != 0)
-                $this->smsProvider->send("Your verification code is " . $ticket, $current_user->phone);
+            $this->smsProvider->send("Your verification code is " . $ticket, $current_user->phone);
             return ['ticket' => $ticket];
         } catch (BadRequestHttpException $e) {
             return $this->response->errorBadRequest($e->getMessage());
@@ -308,7 +303,7 @@ class TransactionsController extends AuthController
                 throw new UnauthorizedException("User does not have permissions to access this transaction");
             }
 
-            if (strcmp($request['otpSmsCode'], $transaction->ticket_otp) != 0) {
+            if (env('SMS_PROVIDER') != null && strcmp($request['otpSmsCode'], $transaction->ticket_otp) != 0) {
                 throw new UnauthorizedException("The supplied code is incorrect");
             }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -33,5 +33,6 @@
         <env name="QUEUE_DRIVER" value="sync"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="SMS_PROVIDER" value="NEXMO"/>
     </php>
 </phpunit>

--- a/tests/Feature/TransactionsControllerTest.php
+++ b/tests/Feature/TransactionsControllerTest.php
@@ -969,40 +969,6 @@ class TransactionsControllerTest extends BrowserKitTestCase
 
     /**
      * @test
-     * If receives all zeroes on the payload, then skips sending an SMS
-     */
-    public function given_allZeroesOnPayload_When_signatureOtp_Then_SkipsSMSSending() {
-
-        $user = factory(\App\User::class)->create([
-            'phone'     => '+34123456789'
-        ]);
-        $agent = factory(Agent::class)->create();
-        $transaction = factory(\App\Transaction::class)->create([
-            'user_id'                => $user->id,
-            'agent_destination'     => $agent->id
-        ]);
-
-        // Act
-        $result = $this->post('/api/transactions/' . $transaction->id . '/signature_otp', [
-            'signatureData'         => [0, 0, 0],
-            'signaturePositions'    => [1, 2, 3]
-        ], $this->headers($user));
-
-        // Assert
-        $result->seeStatusCode(200)
-            ->seeJsonStructure(['ticket']);
-
-        // Check a code has been saved for this transaction
-        $updated_transaction = \App\Transaction::where('id', $transaction->id)->first();
-        self::assertNotNull($updated_transaction);
-        self::assertNotNull($updated_transaction->ticket_otp);
-
-        // Assert SMS was sent
-        self::assertFalse($this->smsrepository->sendCalled);
-    }
-
-    /**
-     * @test
      * Cannot confirm SMS if user is not authorized
      */
     public function given_noAuthorization_When_confirmOtpSMS_Then_Returns401() {


### PR DESCRIPTION
Removes checking for all zeroes within the signature in order to proceed or skip the sms sending. The SMS provider is specified within the environment variables.
To confirm the OTP, the server checks for a valid provider. If no valid provider is specified within the environment, will behave as any token is valid.